### PR TITLE
Move all functions in Utils.h into the utils namespace

### DIFF
--- a/Firmware/UI/Screens/MainPage.cpp
+++ b/Firmware/UI/Screens/MainPage.cpp
@@ -60,8 +60,8 @@ void MainPage::DigitalGainButtonHandler(void* sender)
 
 void MainPage::Draw(IPainter* painter)
 {
-    painter->DrawIcon(&ApertusTextLogo, 58, 89, RGB565(194, 191, 188));
-    painter->DrawIcon(&ApertusRingLogo, 58 + ApertusTextLogo.Width, 89, RGB565(244, 114, 72));
+    painter->DrawIcon(&ApertusTextLogo, 58, 89, utils::RGB565(194, 191, 188));
+    painter->DrawIcon(&ApertusRingLogo, 58 + ApertusTextLogo.Width, 89, utils::RGB565(244, 114, 72));
 
     for (uint8_t index = 0; index < 6; index++)
     {

--- a/Firmware/UI/Screens/Menu.h
+++ b/Firmware/UI/Screens/Menu.h
@@ -82,15 +82,15 @@ class Menu : public IMenu
         _menuBreadcrumbs = "Menu";
 
         // Color defintions
-        _menuBackgroundColor = RGB565(180, 180, 180);
+        _menuBackgroundColor = utils::RGB565(180, 180, 180);
         _menuItemColor = (uint16_t)Color565::White;
-        _menuSelectedItemColor = RGB565(255, 128, 0);
-        _menuDimmedItemColor = RGB565(247, 251, 247);
-        _menuSelectedTextColor = RGB565(255, 255, 255);
-        _menuHightlightedItemColor = RGB565(0, 128, 255);
+        _menuSelectedItemColor = utils::RGB565(255, 128, 0);
+        _menuDimmedItemColor = utils::RGB565(247, 251, 247);
+        _menuSelectedTextColor = utils::RGB565(255, 255, 255);
+        _menuHightlightedItemColor = utils::RGB565(0, 128, 255);
         _menuTextColor = (uint16_t)Color565::Black;
-        _menuDisabledTextColor = RGB565(40, 40, 40);
-        _menuDisabledItemColor = RGB565(180, 180, 180);
+        _menuDisabledTextColor = utils::RGB565(40, 40, 40);
+        _menuDisabledItemColor = utils::RGB565(180, 180, 180);
 
         // init menu selection indexes
         _parameterMenuActive = 0;
@@ -218,7 +218,7 @@ class Menu : public IMenu
         }
 
         // only up to 7 menu items fit on screen at once
-        uint8_t displayItemsCount = LimitRange(_menuItemsCount, 0, 7);
+        uint8_t displayItemsCount = utils::LimitRange(_menuItemsCount, 0, 7);
 
         for (uint8_t itemIndex = 0; itemIndex < displayItemsCount; itemIndex++)
         {
@@ -424,7 +424,7 @@ class Menu : public IMenu
             _menuItem[_menuSelectionIndex]->SetHighlighted(false);
 
             _menuSelectionIndex--;
-            _menuSelectionIndex = LimitRange(_menuSelectionIndex, 0, _menuItemsCount - 1);
+            _menuSelectionIndex = utils::LimitRange(_menuSelectionIndex, 0, _menuItemsCount - 1);
             _menuItem[_menuSelectionIndex]->SetHighlighted(true);
         }
     }
@@ -461,7 +461,7 @@ class Menu : public IMenu
             _menuItem[_menuSelectionIndex]->SetHighlighted(false);
 
             _menuSelectionIndex++;
-            _menuSelectionIndex = LimitRange(_menuSelectionIndex, 0, _menuItemsCount - 1);
+            _menuSelectionIndex = utils::LimitRange(_menuSelectionIndex, 0, _menuItemsCount - 1);
             _menuItem[_menuSelectionIndex]->SetHighlighted(true);
         }
     }

--- a/Firmware/UI/Screens/ParameterListScreen.h
+++ b/Firmware/UI/Screens/ParameterListScreen.h
@@ -39,7 +39,7 @@ class ParameterListScreen : public IScreen
         IScreen(usbDevice), _cancelButton("Cancel"), _setButton("Set"), _header("Parameter Menu"),
         _previousOptionIndex(0), _highlightIndex(0), _optionLineHeight(35), _backgroundColor((uint16_t)Color565::White),
         _textColor((uint16_t)Color565::Black), _highlightColor((uint16_t)Color565::AXIOM_Orange),
-        _highlightTextColor((uint16_t)Color565::White), _backgroundPressedColor(RGB565(0, 128, 255)),
+        _highlightTextColor((uint16_t)Color565::White), _backgroundPressedColor(utils::RGB565(0, 128, 255)),
         _textPressedColor((uint16_t)Color565::White), _pressedIndex(-1)
     {
         //_cancelButton.SetHandler(&CancelButtonHandler);

--- a/Firmware/UI/Widgets/ButtonBar.h
+++ b/Firmware/UI/Widgets/ButtonBar.h
@@ -25,7 +25,7 @@ class ButtonBar : public IWidget
 
   public:
     ButtonBar(uint16_t x, uint16_t y, uint16_t width, uint16_t height) :
-        IWidget(x, y, width, height), _backgroundColor(RGB565(97, 92, 91)), _marginTop(1), _buttonMargin(4)
+        IWidget(x, y, width, height), _backgroundColor(utils::RGB565(97, 92, 91)), _marginTop(1), _buttonMargin(4)
     {
     }
 

--- a/Firmware/UI/Widgets/ImageButton.h
+++ b/Firmware/UI/Widgets/ImageButton.h
@@ -45,8 +45,8 @@ class ImageButton : public IButton
     explicit ImageButton(const Icon* icon, uint16_t x = 0, uint16_t y = 0, uint16_t width = 0, uint16_t height = 0) :
         IButton(x, y, width, height), _image(icon), _cornerRadius(3), _highlighted(false),
         _imageColor((uint16_t)Color565::Black), _currentImageColor(_imageColor),
-        _backgroundHighlightColor((uint16_t)Color565::AXIOM_Blue), _currentBackgroundColor(RGB565(220, 220, 220)),
-        _backgroundColor(RGB565(220, 220, 220)), _buttonStyle(ButtonStyle::Icon)
+        _backgroundHighlightColor((uint16_t)Color565::AXIOM_Blue), _currentBackgroundColor(utils::RGB565(220, 220, 220)),
+        _backgroundColor(utils::RGB565(220, 220, 220)), _buttonStyle(ButtonStyle::Icon)
     {
         _totalWidth = _image->Width;
         _textPositionY = _height / 2;

--- a/Firmware/UI/Widgets/ImageButton.h
+++ b/Firmware/UI/Widgets/ImageButton.h
@@ -45,8 +45,9 @@ class ImageButton : public IButton
     explicit ImageButton(const Icon* icon, uint16_t x = 0, uint16_t y = 0, uint16_t width = 0, uint16_t height = 0) :
         IButton(x, y, width, height), _image(icon), _cornerRadius(3), _highlighted(false),
         _imageColor((uint16_t)Color565::Black), _currentImageColor(_imageColor),
-        _backgroundHighlightColor((uint16_t)Color565::AXIOM_Blue), _currentBackgroundColor(utils::RGB565(220, 220, 220)),
-        _backgroundColor(utils::RGB565(220, 220, 220)), _buttonStyle(ButtonStyle::Icon)
+        _backgroundHighlightColor((uint16_t)Color565::AXIOM_Blue),
+        _currentBackgroundColor(utils::RGB565(220, 220, 220)), _backgroundColor(utils::RGB565(220, 220, 220)),
+        _buttonStyle(ButtonStyle::Icon)
     {
         _totalWidth = _image->Width;
         _textPositionY = _height / 2;

--- a/Firmware/UI/Widgets/MenuItem.h
+++ b/Firmware/UI/Widgets/MenuItem.h
@@ -61,10 +61,10 @@ class MenuItem : public IWidget
              MenuItemType type = MenuItemType::MENU_ITEM_TYPE_NONE) :
         _disabled(disabled),
         _hidden(hidden), _pressed(pressed), _highlighted(highlighted), _label(label), _value(value), _type(type),
-        _backgroundColor((uint16_t)Color565::White), _backgroundHighlightColor(RGB565(255, 128, 0)),
-        _backgroundPressedColor(RGB565(0, 128, 255)), _backgroundDisabledColor(RGB565(180, 180, 180)),
+        _backgroundColor((uint16_t)Color565::White), _backgroundHighlightColor(utils::RGB565(255, 128, 0)),
+        _backgroundPressedColor(utils::RGB565(0, 128, 255)), _backgroundDisabledColor(utils::RGB565(180, 180, 180)),
         _textColor((uint16_t)Color565::Black), _textHighlightColor((uint16_t)Color565::White),
-        _textPressedColor((uint16_t)Color565::White), _textDisabledColor(RGB565(180, 180, 180)),
+        _textPressedColor((uint16_t)Color565::White), _textDisabledColor(utils::RGB565(180, 180, 180)),
         _currentBackgroundColor(_backgroundColor), _currentTextColor(_textColor), _verticalLabelOffset(20),
         _db(centralDB), _handlerPtr(nullptr)
     {

--- a/Firmware/UI/Widgets/ParameterMenuItem.h
+++ b/Firmware/UI/Widgets/ParameterMenuItem.h
@@ -38,10 +38,10 @@ class ParameterMenuItem : public IWidget
                       bool hidden = false, bool pressed = false, bool highlighted = false) :
         _disabled(disabled),
         _hidden(hidden), _pressed(pressed), _highlighted(highlighted), _label(label), _value(value),
-        _backgroundColor((uint16_t)Color565::White), _backgroundHighlightColor(RGB565(255, 128, 0)),
-        _backgroundPressedColor(RGB565(0, 128, 255)), _backgroundDisabledColor(RGB565(180, 180, 180)),
+        _backgroundColor((uint16_t)Color565::White), _backgroundHighlightColor(utils::RGB565(255, 128, 0)),
+        _backgroundPressedColor(utils::RGB565(0, 128, 255)), _backgroundDisabledColor(utils::RGB565(180, 180, 180)),
         _textColor((uint16_t)Color565::Black), _textHighlightColor((uint16_t)Color565::White),
-        _textPressedColor((uint16_t)Color565::White), _textDisabledColor(RGB565(180, 180, 180)),
+        _textPressedColor((uint16_t)Color565::White), _textDisabledColor(utils::RGB565(180, 180, 180)),
         _currentBackgroundColor(_backgroundColor), _currentTextColor(_textColor), _verticalLabelOffset(20),
         _previousChoice(false)
     {

--- a/Firmware/UI/Widgets/PopUpParameterMenu.h
+++ b/Firmware/UI/Widgets/PopUpParameterMenu.h
@@ -31,7 +31,7 @@ class PopUpParameterMenu : public IWidget
 
   public:
     PopUpParameterMenu(uint16_t x, uint16_t y) :
-        IWidget(x, y, 0, 0), _backgroundColor(RGB565(97, 92, 91)), _borderwidth(2), _choiceCount(1),
+        IWidget(x, y, 0, 0), _backgroundColor(utils::RGB565(97, 92, 91)), _borderwidth(2), _choiceCount(1),
         _highlightIndex(-1), _pressedIndex(-1), _horizontalTextMargin(10), _previousChoiceIndex(0)
     {
         _height = _borderwidth * 2 + _choiceCount * 30;

--- a/Firmware/UI/Widgets/PushButton.h
+++ b/Firmware/UI/Widgets/PushButton.h
@@ -27,7 +27,7 @@ class PushButton : public IButton
         IButton(x, y, width, height), _label(label), _cornerRadius(3), _highlighted(false)
     {
         _currentTextColor = _TextColor = (uint16_t)Color565::Black;
-        _currentBackgroundColor = _BackgroundColor = RGB565(220, 220, 220);
+        _currentBackgroundColor = _BackgroundColor = utils::RGB565(220, 220, 220);
 
         _backgroundHighlightColor = (uint16_t)Color565::AXIOM_Blue;
         _textHighlightColor = (uint16_t)Color565::Black;

--- a/Firmware/UI/Widgets/ToggleButton.h
+++ b/Firmware/UI/Widgets/ToggleButton.h
@@ -30,8 +30,8 @@ class ToggleButton : public IButton
     explicit ToggleButton(const char* label, uint16_t x = 0, uint16_t y = 0, uint16_t width = 0, uint16_t height = 0) :
         IButton(x, y, width, height), _label(label), _cornerRadius(3), _highlighted(false), _checked(true),
         _currentTextColor((uint16_t)Color565::Black), _textColor(_currentTextColor),
-        _currentBackgroundColor(RGB565(220, 220, 220)), _backgroundColor(_currentBackgroundColor),
-        _textDisabledColor(RGB565(180, 180, 180)), _backgroundHighlightColor((uint16_t)Color565::AXIOM_Blue),
+        _currentBackgroundColor(utils::RGB565(220, 220, 220)), _backgroundColor(_currentBackgroundColor),
+        _textDisabledColor(utils::RGB565(180, 180, 180)), _backgroundHighlightColor((uint16_t)Color565::AXIOM_Blue),
         _textHighlightColor((uint16_t)Color565::Black)
     {
     }

--- a/Firmware/Utils.h
+++ b/Firmware/Utils.h
@@ -7,12 +7,17 @@
 
 #define UNUSED(x) (void)(x)
 
-static inline uint16_t RGB565(uint8_t red, uint8_t green, uint8_t blue)
+
+
+namespace utils
+{
+
+inline uint16_t RGB565(uint8_t red, uint8_t green, uint8_t blue)
 {
     return ((red & 0xF8) << 8) | ((green & 0xFC) << 3) | ((blue & 0xF8) >> 3);
 }
 
-static inline int8_t LimitRange(int8_t in, int8_t min, int8_t max)
+inline int8_t LimitRange(int8_t in, int8_t min, int8_t max)
 {
     if (in >= max)
     {
@@ -25,8 +30,6 @@ static inline int8_t LimitRange(int8_t in, int8_t min, int8_t max)
     return in;
 }
 
-namespace utils
-{
 inline void CopyString(char* destination, const char* source, const size_t max_size)
 {
     memset(destination, 0, max_size);

--- a/Firmware/Utils.h
+++ b/Firmware/Utils.h
@@ -7,8 +7,6 @@
 
 #define UNUSED(x) (void)(x)
 
-
-
 namespace utils
 {
 


### PR DESCRIPTION
Previously, only one of the functions in `Utils.h` was placed in the `utils` namespace,
the rest being part of the global one. 
`RGB565` and `LimitRange` have now been moved into the namespace too.