### PR TITLE
XC32 v3.00 release

### DIFF
--- a/Bootloader/Main.cpp
+++ b/Bootloader/Main.cpp
@@ -1,6 +1,9 @@
 // MCU header
 //#include <xc.h>
 
+#include <cstdio>
+#include <cstring>
+
 // Configuration
 #include "Configuration/PIC32.h"
 

--- a/Bootloader/Makefile
+++ b/Bootloader/Makefile
@@ -1,5 +1,6 @@
 # Change to the path of XC32 installation, default is /opt/microchip/xc32/<version>/
-XC32_PATH=/opt/microchip/xc32/v2.50
+XC32_PATH=/opt/microchip/xc32/v3.00
+GCC_PATH=${XC32_PATH}/lib/gcc/pic32mx/8.3.1/
 CC=${XC32_PATH}/bin/xc32-g++
 LD=${XC32_PATH}/bin/xc32-ld
 
@@ -15,7 +16,7 @@ INC_DIR=-I${XC32_PATH}/pic32mx/include -I../Common
 SOURCE_FILES=$(wildcard *.cpp) $(wildcard **/*.cpp) $(wildcard Periphery/**/*.cpp)
 OBJ_FILES=${SOURCE_FILES:%.cpp=${BUILD_DIR}/%.o}
 
-OPTS=-c -G0 -mprocessor=${DEVICE} -mconfig-data-dir=${XC32_PATH}/pic32mx/lib/proc/${DEVICE} -iprefix ${XC32_PATH}/lib/gcc/pic32mx/4.8.3/ -Wall -MMD -MF ${BUILD_DIR}/.depend
+OPTS=-c -G0 -mprocessor=${DEVICE} -mconfig-data-dir=${XC32_PATH}/pic32mx/lib/proc/${DEVICE} -iprefix ${GCC_PATH} -Wall -MMD -MF ${BUILD_DIR}/.depend
 LD_OPTS= -Wl,--defsym=_min_heap_size=128,--defsym=_ebase_address=0x9FC01000,--trace,--script="${LINKER_SCRIPT}",--cref,-Map="${BUILD_DIR}/${NAME}.map",--report-mem,--warn-section-align,--memorysummary=${BUILD_DIR}/memoryfile.xml
 
 all: ${BUILD_DIR}/${NAME}.elf

--- a/Firmware/Makefile
+++ b/Firmware/Makefile
@@ -1,5 +1,6 @@
 # Change to the path of XC32 installation, default is /opt/microchip/xc32/<version>/
-XC32_PATH=/opt/microchip/xc32/v2.50
+XC32_PATH=/opt/microchip/xc32/v3.00
+GCC_PATH=${XC32_PATH}/lib/gcc/pic32mx/8.3.1/
 CC=${XC32_PATH}/bin/xc32-g++
 LD=${XC32_PATH}/bin/xc32-ld
 
@@ -16,7 +17,7 @@ INC_DIR=-I${XC32_PATH}/pic32mx/include -I../Common
 SOURCE_FILES=$(wildcard *.cpp) $(wildcard **/*.cpp) $(wildcard UI/**/*.cpp) $(wildcard ../Bootloader/Periphery/**/*.cpp)
 OBJ_FILES=${SOURCE_FILES:%.cpp=${BUILD_DIR}/%.o}
 
-OPTS=-c -G0 -mprocessor=${DEVICE} -mconfig-data-dir=${XC32_PATH}/pic32mx/lib/proc/${DEVICE} -iprefix ${XC32_PATH}/lib/gcc/pic32mx/4.8.3/ -Wall -MMD -MF ${BUILD_DIR}/.depend
+OPTS=-c -G0 -mprocessor=${DEVICE} -mconfig-data-dir=${XC32_PATH}/pic32mx/lib/proc/${DEVICE} -iprefix ${GCC_PATH} -Wall -MMD -MF ${BUILD_DIR}/.depend
 LD_OPTS= -Wl,--defsym=_min_heap_size=128,--trace,--script="${LINKER_SCRIPT}",--cref,-Map="${BUILD_DIR}/${NAME}.map",--report-mem,--warn-section-align,--memorysummary=${BUILD_DIR}/memoryfile.xml
 
 all: ${BUILD_DIR}/${NAME}.elf

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ for details see: LICENSE.txt
 
 [https://www.microchip.com/mplab/compilers](https://www.microchip.com/mplab/compilers). We have tested the code on v2.4.
 
-To be able to build, the variable **XC32_PATH** in the Makefile of firmware and bootloader has to be adjusted to the actual install path of XC32.
+To be able to build, the variables **XC32_PATH** and **GCC_PATH** in the Makefile of firmware and bootloader has to be adjusted to the actual install path of XC32 and gcc compiler of XC32.
 
 ### Bootloader
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ for details see: LICENSE.txt
 
 [https://www.microchip.com/mplab/compilers](https://www.microchip.com/mplab/compilers). We have tested the code on v2.4.
 
-To be able to build, the variables **XC32_PATH** and **GCC_PATH** in the Makefile of firmware and bootloader has to be adjusted to the actual install path of XC32 and gcc compiler of XC32.
+To be able to build, the variables **XC32_PATH** and **GCC_PATH** in the Makefile of firmware and bootloader have to be adjusted to the actual install path of XC32 and gcc compiler of XC32.
 
 ### Bootloader
 


### PR DESCRIPTION
XC32 v3.00 has gcc version 8.3.1 . Previously it was 4.3.1 (v2.50 and older). So, have just adjusted (minor changes) for the same.

Link to release note of MPLAB XC32 V 3.00 -  https://ww1.microchip.com/downloads/en/DeviceDoc/xc32-v3.00-full-install-release-notes.html#Migration

See the **What's New** and **Migration Issues** in release note for new added features and things that are changed or updated.
