### PR TITLE
Done adjustment needed for XC32 v3.00 in makefile of bootloader and firmware

### DIFF
--- a/Bootloader/Main.cpp
+++ b/Bootloader/Main.cpp
@@ -1,6 +1,9 @@
 // MCU header
 //#include <xc.h>
 
+#include <cstdio>
+#include <cstring>
+
 // Configuration
 #include "Configuration/PIC32.h"
 

--- a/Bootloader/Makefile
+++ b/Bootloader/Makefile
@@ -1,5 +1,5 @@
 # Change to the path of XC32 installation, default is /opt/microchip/xc32/<version>/
-XC32_PATH=/opt/microchip/xc32/v2.50
+XC32_PATH=/opt/microchip/xc32/v3.00
 CC=${XC32_PATH}/bin/xc32-g++
 LD=${XC32_PATH}/bin/xc32-ld
 
@@ -15,7 +15,10 @@ INC_DIR=-I${XC32_PATH}/pic32mx/include -I../Common
 SOURCE_FILES=$(wildcard *.cpp) $(wildcard **/*.cpp) $(wildcard Periphery/**/*.cpp)
 OBJ_FILES=${SOURCE_FILES:%.cpp=${BUILD_DIR}/%.o}
 
-OPTS=-c -G0 -mprocessor=${DEVICE} -mconfig-data-dir=${XC32_PATH}/pic32mx/lib/proc/${DEVICE} -iprefix ${XC32_PATH}/lib/gcc/pic32mx/4.8.3/ -Wall -MMD -MF ${BUILD_DIR}/.depend
+# Older version of XC32 uses gcc compiler version 4.8.3 and XC32 v3.00 uses gcc version 8.3.1.
+# So, if using older version of XC32 (v2.50 or older), uncomment line 20 and comment out line 21
+# OPTS=-c -G0 -mprocessor=${DEVICE} -mconfig-data-dir=${XC32_PATH}/pic32mx/lib/proc/${DEVICE} -iprefix ${XC32_PATH}/lib/gcc/pic32mx/4.8.3/ -Wall -MMD -MF ${BUILD_DIR}/.depend
+OPTS=-c -G0 -mprocessor=${DEVICE} -mconfig-data-dir=${XC32_PATH}/pic32mx/lib/proc/${DEVICE} -iprefix ${XC32_PATH}/lib/gcc/pic32mx/8.3.1/ -Wall -MMD -MF ${BUILD_DIR}/.depend
 LD_OPTS= -Wl,--defsym=_min_heap_size=128,--defsym=_ebase_address=0x9FC01000,--trace,--script="${LINKER_SCRIPT}",--cref,-Map="${BUILD_DIR}/${NAME}.map",--report-mem,--warn-section-align,--memorysummary=${BUILD_DIR}/memoryfile.xml
 
 all: ${BUILD_DIR}/${NAME}.elf

--- a/Firmware/Makefile
+++ b/Firmware/Makefile
@@ -1,5 +1,5 @@
 # Change to the path of XC32 installation, default is /opt/microchip/xc32/<version>/
-XC32_PATH=/opt/microchip/xc32/v2.50
+XC32_PATH=/opt/microchip/xc32/v3.00
 CC=${XC32_PATH}/bin/xc32-g++
 LD=${XC32_PATH}/bin/xc32-ld
 
@@ -16,7 +16,10 @@ INC_DIR=-I${XC32_PATH}/pic32mx/include -I../Common
 SOURCE_FILES=$(wildcard *.cpp) $(wildcard **/*.cpp) $(wildcard UI/**/*.cpp) $(wildcard ../Bootloader/Periphery/**/*.cpp)
 OBJ_FILES=${SOURCE_FILES:%.cpp=${BUILD_DIR}/%.o}
 
-OPTS=-c -G0 -mprocessor=${DEVICE} -mconfig-data-dir=${XC32_PATH}/pic32mx/lib/proc/${DEVICE} -iprefix ${XC32_PATH}/lib/gcc/pic32mx/4.8.3/ -Wall -MMD -MF ${BUILD_DIR}/.depend
+# Older version of XC32 uses gcc compiler version 4.8.3 and XC32 v3.00 uses gcc version 8.3.1.
+# If using older version of XC32 (v2.50 or older), uncomment line 21 and comment out line 22
+# OPTS=-c -G0 -mprocessor=${DEVICE} -mconfig-data-dir=${XC32_PATH}/pic32mx/lib/proc/${DEVICE} -iprefix ${XC32_PATH}/lib/gcc/pic32mx/4.8.3/ -Wall -MMD -MF ${BUILD_DIR}/.depend
+OPTS=-c -G0 -mprocessor=${DEVICE} -mconfig-data-dir=${XC32_PATH}/pic32mx/lib/proc/${DEVICE} -iprefix ${XC32_PATH}/lib/gcc/pic32mx/8.3.1/ -Wall -MMD -MF ${BUILD_DIR}/.depend
 LD_OPTS= -Wl,--defsym=_min_heap_size=128,--trace,--script="${LINKER_SCRIPT}",--cref,-Map="${BUILD_DIR}/${NAME}.map",--report-mem,--warn-section-align,--memorysummary=${BUILD_DIR}/memoryfile.xml
 
 all: ${BUILD_DIR}/${NAME}.elf


### PR DESCRIPTION
Release note for xc32 v3.00 - https://ww1.microchip.com/downloads/en/DeviceDoc/xc32-v3.00-full-install-release-notes.html


Current AXIOM Remote's firmware and bootloader wasn't compiling with xc32 v3.00 . That was because the gcc compiler version has been changed in xc32 v3.00 (previously it was 4.8.3, now it is 8.3.1)

So, have made adjustment  for the same